### PR TITLE
feat(sidebar): create and use font context for logo name

### DIFF
--- a/app/FontContext.tsx
+++ b/app/FontContext.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import React, { createContext, useContext } from "react";
+import { Dawning_of_a_New_Day } from "next/font/google";
+
+const dawning = Dawning_of_a_New_Day({ subsets: ["latin"], weight: "400" });
+
+const FontContext = createContext({ dawning });
+
+export const FontProvider = ({ children }: { children: React.ReactNode }) => (
+  <FontContext.Provider value={{ dawning }}>{children}</FontContext.Provider>
+);
+
+export const useFonts = () => useContext(FontContext);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,13 @@
+import React from "react";
+import { FontProvider } from "./FontContext";
+import { Poppins } from "next/font/google";
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
 import "./globals.css";
 
-const inter = Inter({ subsets: ["latin"] });
+const poppins = Poppins({ subsets: ["latin"], weight: "400" });
 
 export const metadata: Metadata = {
-  title: "Martina Mancuso"
+  title: "Martina Mancuso",
 };
 
 export default function RootLayout({
@@ -15,7 +17,9 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={inter.className}>{children}</body>
+      <FontProvider>
+        <body className={`${poppins.className}`}>{children}</body>
+      </FontProvider>
     </html>
   );
 }

--- a/app/ui/sidebar/sidebar.tsx
+++ b/app/ui/sidebar/sidebar.tsx
@@ -3,36 +3,44 @@
 import { useState } from "react";
 import { HamburgerMenuButton } from "../hamburger-menu/hamburger-menu-button";
 import style from "./sidebar.module.scss";
+import { useFonts } from "../../FontContext";
 
 export function Sidebar() {
   const [menuOpen, setMenuOpen] = useState(false);
+  const { dawning } = useFonts();
 
   function toggleMenuOpen() {
     setMenuOpen((prevValue: boolean) => !prevValue);
   }
 
   return (
-    <aside className="fixed lg:relative w-full lg:w-80 lg:shrink-0 bg-white text-center lg:flex lg:flex-col lg:justify-around lg:items-center">
+    <aside className="fixed border-r border-slate-200 lg:relative w-full lg:w-80 lg:shrink-0 bg-white text-center lg:flex lg:flex-col lg:justify-around lg:items-center">
       <header className="h-12 flex items-center justify-between">
-        <span className="p-3">MM</span>
+        <span
+          className={`${dawning.className} text-4xl block`}
+        >
+          Martina Mancuso
+        </span>
         <HamburgerMenuButton
           className="lg:hidden"
           isEnabled={menuOpen}
           onClick={toggleMenuOpen}
         />
       </header>
-      <nav className={`overflow-hidden ${style.menu} ${menuOpen ? style.menuOpen : ""}`}>
+      <nav
+        className={`overflow-hidden ${style.menu} ${
+          menuOpen ? style.menuOpen : ""
+        }`}
+      >
         <ul>
-          <li className="p-2">Home</li>
-          <li className="p-2">About</li>
+          <li className="p-2">home</li>
+          <li className="p-2">about</li>
           {/* <li className="p-2">Portfolio</li> */}
-          <li className="p-2">Blog</li>
-          <li className="p-2">Contact</li>
+          <li className="p-2">blog</li>
+          <li className="p-2">contact</li>
         </ul>
       </nav>
-      <footer className="hidden lg:block">
-        SOCIAL ICONS
-      </footer>
+      <footer className="hidden lg:block">SOCIAL ICONS</footer>
     </aside>
   );
 }


### PR DESCRIPTION
# What

_Describe what you did and what goal is reached with this Pull Request_
- Created a context for "Poppins" font, used for the logo name, in the "Sidebar" component

**Trello task:** 
https://trello.com/c/evYi4H5I/7-add-fonts-to-the-website

## Screenshots

_Mobile_
<img width="878" alt="Screenshot 2024-05-20 alle 18 02 42" src="https://github.com/martinamancuso/martinamancuso.com/assets/141554727/4e73642f-80aa-4255-9cd9-6f9fd326037e">

_Desktop_
<img width="878" alt="Screenshot 2024-05-20 alle 18 03 05" src="https://github.com/martinamancuso/martinamancuso.com/assets/141554727/9335bb31-d4db-400f-a1dd-90ff60044fd8">



# How

_Describe how you did the task and list sub-tasks you did (e.g. created components, created pages, added store, etc.)_

1. Created a new Client component: "FontContext" 

2. Imported it in the "Sidebar" component 

3. Added style rules to `aside` and `span` tags: 
-- `aside`: border-r and its color 
-- `span`: font size